### PR TITLE
Remove inaccurate comment in _flashFee function

### DIFF
--- a/contracts/token/ERC20/extensions/ERC20FlashMint.sol
+++ b/contracts/token/ERC20/extensions/ERC20FlashMint.sol
@@ -42,7 +42,7 @@ abstract contract ERC20FlashMint is ERC20, IERC3156FlashLender {
     }
 
     /**
-     * @dev Returns the fee applied when doing flash loans. This function calls the {flashFee} function which returns the fee applied when doing flash loans.
+     * @dev Returns the fee applied when doing flash loans.
      * @param token The token to be flash loaned.
      * @param amount The amount of tokens to be loaned.
      * @return The fees applied to the corresponding flash loan.


### PR DESCRIPTION
#3551 introduced the `_flashFee` function to `ERC20FlashMint`.

Its docstrings stated that the function called the `flashFee` function, which is not the case. I'm removing it.